### PR TITLE
Changes the CSS path from relative to absolute

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -29,7 +29,7 @@ gulp.task('inject-default', function () {
   // It's not necessary to read the files (will speed up things), we're only after their paths:
   var sources = gulp.src(['source/code/css/*.css', 'source/code/js/*.js'], {read: false});
   // Inject but trim the path to be relative to HTML
-  return target.pipe(inject(sources, {ignorePath: 'source', addRootSlash: false }))
+  return target.pipe(inject(sources, {ignorePath: 'source', addRootSlash: true }))
     .pipe(gulp.dest('source/code/_views'));
 });
 
@@ -39,7 +39,7 @@ gulp.task('inject-min', function () {
   // It's not necessary to read the files (will speed up things), we're only after their paths:
   var sources = gulp.src(['source/code/min/*.css', 'source/code/min/*.js'], {read: false});
   // Inject but trim the path to be relative to HTML
-  return target.pipe(inject(sources, {ignorePath: 'source', addRootSlash: false }))
+  return target.pipe(inject(sources, {ignorePath: 'source', addRootSlash: true }))
     .pipe(gulp.dest('source/code/_views'));
 });
 


### PR DESCRIPTION
See issue: https://github.com/palantirnet/butler/issues/7#issuecomment-145993796

This PR updates the path of the CSS file from a relative path to an absolute path. Because the individual pieces of the styleguide live in the _/styleguide_ folder, the same relative path cannot be used for the HTML files in this directory as can be used for the index.html file.

We simply need to ensure that the prefixing _/_ is added to the path so that it is an absolute path. Changing _addRootSlash_ to _true_ does this.