### PR TITLE
Don't re-create butler.defaults.js

### DIFF
--- a/config/butler.config.sh
+++ b/config/butler.config.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 
-echo "// Project-specific Butler configuration." > ../../conf/butler.defaults.js
-echo "" >> ../../conf/butler.defaults.js
+if [ ! -e ../../conf/butler.defaults.js ]; then
+  echo "// Project-specific Butler configuration." > ../../conf/butler.defaults.js
+  echo "" >> ../../conf/butler.defaults.js
 
-echo "Please provide the repository link for this project. Eg: https://github.com/palantirnet/butler.git"
-read project_repo
-echo "defaults.repo = \"$project_repo\";" >> ../../conf/butler.defaults.js
+  echo "Please provide the repository link for this project. Eg: https://github.com/palantirnet/butler.git"
+  read project_repo
+  echo "defaults.repo = \"$project_repo\";" >> ../../conf/butler.defaults.js
+fi;
 
 echo "Thanks for using Butler!"


### PR DESCRIPTION
If a project already has `conf/butler.defaults.js`, don't try to re-create it.

This is followup to #22 -- now we can check the `conf/butler.defaults.js` into a project's repo, and all the later developers won't need to enter the git URL. Somehow I forgot this crucial piece the first time around.