### PR TITLE
Kill process running on :8000 to remove error.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -64,7 +64,8 @@ gulp.task('sass', function() {
 gulp.task('sculpin', function () {
   console.log('Building sculpin...');
   gulp.src(defaults.sculpin)
-    // Run the command line commands to watch sculpin
+    // Kill process running on :8000. Run the command line commands to watch sculpin
+    .pipe(exec('lsof -ti TCP:8000 | xargs  kill'))
     .pipe(exec(defaults.sculpin_run + ' generate --watch --server --project-dir="' + defaults.sculpin + '"'));
 });
 


### PR DESCRIPTION
events.js:154
      throw er; // Unhandled 'error' event
      ^
Error: Command failed: ../../vendor/bin/sculpin generate --watch --server --project-dir="../../styleguide/"

                                                                
  [React\Socket\ConnectionException]                            
  **Could not bind to tcp://0.0.0.0:8000: Address already in use ** 
                                                                

generate [--watch] [--server] [--url URL] [--port PORT]


    at ChildProcess.exithandler (child_process.js:202:12)
    at emitTwo (events.js:100:13)
    at ChildProcess.emit (events.js:185:7)
    at maybeClose (internal/child_process.js:850:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:5)