### PR TITLE
Add drupal-attach-behaviors.js file

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ A tool to automate front-end development tasks and streamline prototyping.
 
   *Note: When you are deploying, Butler will ask you for your GitHub credentials at least once, possibly multiple times. Enter your own GitHub credentials as prompted.*
 
+## Writing Javascript
+If you need to write some Javascript, follow the [instructions at `/docs/JS.md`](https://github.com/palantirnet/butler/blob/drupal-attach-behaviors/docs/JS.md) to properly set up your scripts. This will allow for Javascript to be shared between the styleguide and Drupal.
+
 ## Troubleshooting
 
 For immediate concerns, if you have comments/questions/concerns about working with this please talk to Lauren.

--- a/STYLEGUIDE_TEMPLATE/source/code/_views/default.html
+++ b/STYLEGUIDE_TEMPLATE/source/code/_views/default.html
@@ -9,6 +9,10 @@
     <!-- endinject -->
     <link rel="shortcut icon" href="{{ site.url }}assets/images/global/palantir-favicon.png?v=2" type="image/x-icon" />
     <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script type="text/javascript" src="/code/libraries/drupal-attach-behaviors.js"></script>
+    <script src="/code/js/script.js"></script>
+    <!-- Add additional custom scripts below -->
+
   </head>
   <body>
        {% block content_wrapper %}{% block content %}{% endblock %}{% endblock %}

--- a/STYLEGUIDE_TEMPLATE/source/code/_views/default.html
+++ b/STYLEGUIDE_TEMPLATE/source/code/_views/default.html
@@ -12,7 +12,6 @@
     <script type="text/javascript" src="/code/libraries/drupal-attach-behaviors.js"></script>
     <script src="/code/js/script.js"></script>
     <!-- Add additional custom scripts below -->
-
   </head>
   <body>
        {% block content_wrapper %}{% block content %}{% endblock %}{% endblock %}

--- a/STYLEGUIDE_TEMPLATE/source/code/_views/styleguide.html
+++ b/STYLEGUIDE_TEMPLATE/source/code/_views/styleguide.html
@@ -9,6 +9,9 @@
     <!-- endinject -->
     <link rel="shortcut icon" href="{{ site.url }}/assets/images/global/palantir-favicon.png?v=2" type="image/x-icon" />
     <script src="http://code.jquery.com/jquery-latest.js"></script>
+    <script type="text/javascript" src="/code/libraries/drupal-attach-behaviors.js"></script>
+    <script src="/code/js/script.js"></script>
+    <!-- Add additional custom scripts below -->
   </head>
   <body>
        {% block content_wrapper %}{% block content %}{% endblock %}{% endblock %}

--- a/STYLEGUIDE_TEMPLATE/source/code/js/script.js
+++ b/STYLEGUIDE_TEMPLATE/source/code/js/script.js
@@ -1,0 +1,22 @@
+/**
+ * @file
+ * A Javascript file that is run on every page load.
+ *
+ * JavaScript should be made compatible with libraries other than jQuery by
+ * wrapping it with an "anonymous closure". See:
+ * - https://drupal.org/node/1446420
+ * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
+ *
+ * @copyright Copyright (c) 2016 Palantir.net
+ */
+
+(function ($, Drupal) {
+  Drupal.behaviors.script = {
+      attach: function (context, settings) {
+          (function ($) {
+              // Insert your Javascript here
+              
+          })(jQuery);
+      }
+  };
+})(jQuery, Drupal);

--- a/STYLEGUIDE_TEMPLATE/source/code/libraries/drupal-attach-behaviors.js
+++ b/STYLEGUIDE_TEMPLATE/source/code/libraries/drupal-attach-behaviors.js
@@ -1,0 +1,33 @@
+/**
+ * A helper script that mimics the Drupal Javascript API.
+ *
+ * This allows for scripts to be written like they would for Drupal (by
+ * attaching behaviors) in the styleguide. As a result, scripts function
+ * properly for the styleguide and may simply be symlinked to the /themes
+ * directory in Drupal.
+ */
+
+window.Drupal = {behaviors: {}, locale: {}};
+
+(function ($) {
+  Drupal.attachBehaviors = function (context, settings) {
+    context = context || document;
+    settings = settings || {};
+    var behaviors = Drupal.behaviors;
+    // Execute all of them.
+    for (var i in behaviors) {
+      if (behaviors.hasOwnProperty(i) && typeof behaviors[i].attach === 'function') {
+        // Don't stop the execution of behaviors in case of an error.
+        try {
+          behaviors[i].attach(context, settings);
+        }
+        catch (e) {
+          console.log(e);
+        }
+      }
+    }
+  };
+
+  // Attach all behaviors.
+  $('document').ready(function () { Drupal.attachBehaviors(document, {}); });
+})(jQuery);

--- a/docs/JS.md
+++ b/docs/JS.md
@@ -1,0 +1,30 @@
+# Writing JS with Butler for Drupal #
+
+### Overview ###
+Drupal prefers that scripts be [attached using behaviors](https://www.drupal.org/node/2269515) so that code runs both on normal page loads, when data is loaded by AJAX and in other instances when Drupal deems necessary for the behavior to be run.
+
+Allowing scripts in the styleguide to be written as Drupal behaviors allows for the scripts to be symlinked to the Drupal `/themes` directory. The scripts, however, break when used in the styleguide.
+
+As a result, a custom script (_drupal-attach-behaviors.js_) mimics the functionality from the Drupal JS API. It lives at `/source/code/libraries/drupal-attach-behaviors.js`. This allows us to write our scripts as Drupal behaviors and use them in the styleguide. With _drupal-attach-behaviors.js_ included in the `<head>` of your styleguide, the scripts work properly—both in Drupal and in the styleguide—with the scripts living in only one location.
+
+### Setup ###
+#### Styleguide ####
+Including the _drupal-attach-behaviors.js_ script will need to be done before any custom scripts are declared in the appropriate HTML file in the styleguide (like default.html and styleguide.html):
+```
+<script type="text/javascript" src="/code/libraries/drupal-attach-behaviors.js"></script>
+<script src="/code/js/alert.js"></script>
+<script src="/code/js/cards.js"></script>
+<script src="/code/js/filter.js"></script>
+```
+
+#### Drupal ####
+No additional work is required for the scripts to work within Drupal. The appropriate files just need symlinked to your theme's root folder.
+
+### Writing Javascript ###
+Once _drupal-attach-behaviors.js_ is included, you're ready to write some Javascript. It's best to encapsulate the Javascript used on the site into separate pieces based on functionality. This way, only the necessary Javascript is loaded on a page.
+
+1. Create a new Javascript file in the `/source/code/js` directory. Note, if this is the first script you're writing, you may need to create the directory.
+2. Copy and paste the [Javascript file template](https://github.com/palantirnet/butler/blob/drupal-attach-behaviors/docs/JS_TEMPLATE.js) into your new file. (The template is located at /docs/JS_TEMPLATE.js)
+3. Update the potions in curly brackets: the file description comment, the name of the behavior and the contents of the script you're writing.
+4. Include the Javascript file in the `<head>` of your HTML file **after** the `drupal-attach-behaviors.js` script.
+5. If you need to create additional scripts, just copy this process.

--- a/docs/JS.md
+++ b/docs/JS.md
@@ -9,22 +9,26 @@ As a result, a custom script (_drupal-attach-behaviors.js_) mimics the functiona
 
 ### Setup ###
 #### Styleguide ####
-Including the _drupal-attach-behaviors.js_ script will need to be done before any custom scripts are declared in the appropriate HTML file in the styleguide (like default.html and styleguide.html):
+Including the _drupal-attach-behaviors.js_ script will need to be done before any custom scripts are declared in the appropriate HTML file in the styleguide (like default.html and styleguide.html). This is done by default in the styleguide:
 ```
 <script type="text/javascript" src="/code/libraries/drupal-attach-behaviors.js"></script>
 <script src="/code/js/alert.js"></script>
 <script src="/code/js/cards.js"></script>
 <script src="/code/js/filter.js"></script>
+<script src="/code/js/etc.js"></script>
 ```
 
 #### Drupal ####
-No additional work is required for the scripts to work within Drupal. The appropriate files just need symlinked to your theme's root folder.
+No additional work is required for the scripts to work within Drupal. The appropriate files just need to be symbolically linked to your theme's root folder.
 
 ### Writing Javascript ###
 Once _drupal-attach-behaviors.js_ is included, you're ready to write some Javascript. It's best to encapsulate the Javascript used on the site into separate pieces based on functionality. This way, only the necessary Javascript is loaded on a page.
 
-1. Create a new Javascript file in the `/source/code/js` directory. Note, if this is the first script you're writing, you may need to create the directory.
+By default, a `scripts.js` file has been added to the `js/` folder. It is loaded on every page in the styleguide and in Drupal. If you have site-wide scripts to write (perhaps opening/closing mobile navigation), this would be the place to include this code. Otherwise, if code is only being used on a single page or group of pages, creating a new Javascript file is preferred.
+
+#### Creating a new, custom Javascript file ####
+1. Create a new Javascript file in the `/source/code/js` directory.
 2. Copy and paste the [Javascript file template](https://github.com/palantirnet/butler/blob/drupal-attach-behaviors/docs/JS_TEMPLATE.js) into your new file. (The template is located at /docs/JS_TEMPLATE.js)
-3. Update the potions in curly brackets: the file description comment, the name of the behavior and the contents of the script you're writing.
+3. Update the potions in curly brackets: the file description comment, the name of the behavior and the contents of the script you're writing. You many name your behavior anything you like; it just needs to be unique.
 4. Include the Javascript file in the `<head>` of your HTML file **after** the `drupal-attach-behaviors.js` script.
-5. If you need to create additional scripts, just copy this process.
+5. If you need to create additional scripts, just repeat this process.

--- a/docs/JS_TEMPLATE.js
+++ b/docs/JS_TEMPLATE.js
@@ -1,0 +1,20 @@
+/**
+ * @file
+ * {{ A brief description of what this Javascript does. }}
+ *
+ * JavaScript should be made compatible with libraries other than jQuery by
+ * wrapping it with an "anonymous closure". See:
+ * - https://drupal.org/node/1446420
+ * - http://www.adequatelygood.com/2010/3/JavaScript-Module-Pattern-In-Depth
+ *
+ * @copyright Copyright (c) 2016 Palantir.net
+ */
+(function ($, Drupal) {
+  Drupal.behaviors.{{ some unique name }} = {
+      attach: function (context, settings) {
+          (function ($) {
+              {{ script here }}
+          })(jQuery);
+      }
+  };
+})(jQuery, Drupal);


### PR DESCRIPTION
Drupal prefers that scripts be [attached using behaviors](https://www.drupal.org/node/2269515) so that code runs both on normal page loads and when data is loaded by AJAX.

Allowing scripts in the styleguide to be Drupal behaviors allows for the scripts to be symlinked to the `/themes` directory. The scripts, however, break when used in the styleguide.

As a result, a custom script (_drupal-attach-behaviors.js_) mimics the functionality from the Drupal JS API allowing us to write our scripts as Drupal behaviors and use them in the styleguide. With _drupal-attach-behaviors.js_ in place, the scripts work properly—both in Drupal and in the styleguide—with the scripts living in only one location.

This pull request adds the _drupal-attach-behaviors.js_ script and updates the script files from the styleguide to use Drupal behaviors. Manual testing was done to ensure the scripts did not break.
#### Effect on developers/designers
- Front end developers will likely see little change to their workflow since the scripts are still symlinked to the appropriate folder in the theme. They will benefit from the fact that the scripts are appropriately contained in Drupal behaviors
- Designers will have to make slight modifications to their workflow when writing Javascript. Any new scripts will need to follow the standard Drupal behavior template:

```
Drupal.behaviors.{{ some unique name }} = {
    attach: function (context, settings) {
        (function ($) {
            {{ script here }}
        })(jQuery);
    }
};
```
- In addition, a one time update of including the _drupal-attach-behaviors.js_ script will need to be done before any custom scripts are declared in the appropriate HTML file in the styleguide (default.html and styleguide.html) like so:

```
<script type="text/javascript" src="/code/libraries/drupal-attach-behaviors.js"></script>
<script src="/code/js/alert.js"></script>
<script src="/code/js/cards.js"></script>
<script src="/code/js/filter.js"></script>
```
- On the Drupal end, nothing will be changed as the scripts are written in Drupal's behavior pattern. The _drupal-attach-behaviors.js_ script does _not_ to be included in Drupal. The scripts will need to be symlinked to Drupal.
#### Potential Drawbacks

There is a small amount of overhead in the styleguide due to the inclusion of an additional script. There's also the possibility that some Javascript may break in the styleguide (although this has not been the case thus far).
#### Other potential solutions
- Replicate scripts in the `/themes/js` folder and manually add the behavior code
- Use something in our build process to append the appropriate behavior wrapping code before copying the script into the `/themes/js` folder

I prefer the method implemented in this PR because there is only one copy of the Javascript file. Otherwise, code has the potential to diverge from one another.
