### PR TITLE
Added includePaths to singularity and breakpoint modules

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -52,7 +52,13 @@ gulp.task('sass', function() {
       stylelint(defaults.stylelint),
       reporter({ clearMessages: true })
     ], {syntax: syntax_scss}))
-    .pipe(sass().on('error',sass.logError))
+    // Include paths to sass modules
+    .pipe(sass({
+      includePaths: [
+        'node_modules/singularitygs/stylesheets/',
+        'node_modules/breakpoint-sass/stylesheets/'
+      ]
+    }).on('error',sass.logError))
     // Run postcss plugin functions
     .pipe(postcss(processors))
     // Put the CSS in the destination dir

--- a/STYLEGUIDE_TEMPLATE/source/code/sass/_init.scss
+++ b/STYLEGUIDE_TEMPLATE/source/code/sass/_init.scss
@@ -154,9 +154,10 @@ $indent-amount: 1em;
 // =============================================================================
 
 // Add the Singularity Grids responsive layout mixins.
-@import "../../../../node_modules/butler/node_modules/singularitygs/stylesheets/singularitygs";
+@import "singularitygs";
+
 // Add the Breakpoint mixin.
-@import "../../../../node_modules/butler/node_modules/breakpoint-sass/stylesheets/breakpoint";
+@import "breakpoint";
 
 // Now we add our custom helper mixins.
 @import "mixins";


### PR DESCRIPTION
We can utilize `includePaths` within the `gulpfile.js` to set the paths to whatever sass modules we have installed within the node_modules directory. This cleans up the import path in the `_init.scss` file.
