### PR TITLE
Specify the required node version in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A tool to automate front-end development tasks and streamline prototyping.
 
 ## Dependencies
 
-* **NodeJS**
-  1. If you are running Butler on your local machine, you can install using Homebrew: `brew install node`
+* **NodeJS 4.x**
+  1. If you are running Butler on your local machine, you can install using Homebrew: `brew install homebrew/versions/node4-lts`
   1. If you are running Butler on a Vagrant, our default VM comes with node installed.
 * **Sculpin**
   1. Butler expects Sculpin to be included in your project using `composer`. Make sure you've run `composer install` in your project before running Butler.


### PR DESCRIPTION
In my brief testing, Butler doesn't work with Node 5.x or Node 6.x; it currently requires Node 4.x. My errors from 5.x look like this:

```
[11:55P white@grattitude:~/repos/academyhealth/styleguide] (develop) $ npm run butler

> academyhealth@1.0.0 butler /Users/white/repos/academyhealth
> node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js

[11:56:09] Working directory changed to ~/repos/academyhealth/node_modules/butler
/Users/white/repos/academyhealth/node_modules/butler/node_modules/node-sass/lib/index.js:15
    throw new Error(errors.missingBinary());
    ^

Error: Missing binding /Users/white/repos/academyhealth/node_modules/butler/node_modules/node-sass/vendor/darwin-x64-47/binding.node
Node Sass could not find a binding for your current environment: OS X 64-bit with Node.js 5.x

Found bindings for the following environments:
  - Linux 64-bit with Node 0.12.x

This usually happens because your environment has changed since running `npm install`.
Run `npm rebuild node-sass` to build the binding for your current environment.
    at Object.<anonymous> (/Users/white/repos/academyhealth/node_modules/butler/node_modules/node-sass/lib/index.js:15:11)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
    at Module.require (module.js:367:17)
    at require (internal/module.js:16:19)
    at Object.<anonymous> (/Users/white/repos/academyhealth/node_modules/butler/node_modules/gulp-sass/index.js:187:21)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)

npm ERR! Darwin 14.5.0
npm ERR! argv "/usr/local/Cellar/node/5.8.0/bin/node" "/usr/local/bin/npm" "run" "butler"
npm ERR! node v5.8.0
npm ERR! npm  v3.7.3
npm ERR! code ELIFECYCLE
npm ERR! academyhealth@1.0.0 butler: `node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the academyhealth@1.0.0 butler script 'node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the academyhealth package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js
npm ERR! You can get information on how to open an issue for this project with:
npm ERR!     npm bugs academyhealth
npm ERR! Or if that isn't available, you can get their info via:
npm ERR!     npm owner ls academyhealth
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/white/repos/academyhealth/styleguide/npm-debug.log
```

Maybe running `npm rebuild node-sass` would have fixed this.