### PR TITLE
[Spress] : Watch for CSS changes in addition to HTML changes

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -100,7 +100,7 @@ gulp.task('sculpin-prod', function () {
 
 // Spress Development
 gulp.task('spress-watch', function() {
-  var watcher = gulp.watch([defaults.spress_home + 'src/content/*', defaults.spress_home + 'src/**/*.html*'], ['spress-build']);
+  var watcher = gulp.watch([defaults.spress_home + 'src/content/*', defaults.spress_home + 'src/**/*.html*', defaults.spress_home + 'src/content/assets/css/*'], ['spress-build']);
   watcher.on('change', function(event) {
     console.log('File ' + event.path + ' was ' + event.type + ', updating spress...');
   });


### PR DESCRIPTION
This pull request fixes an issue identified in the `spress-task` PR. 

**Problem:**
Sass is recompiled automatically through Gulp, but Spress is not rebuilt. As a result, the newly generated stylesheet is not included when the page is refreshed. Butler must be re-run to force Spress to grab the new stylesheet.

**Solution:**
In addition to watching for HTML file changes, also watch for CSS changes in the `assets/` directory.

**Testing:**
- To test this PR, install Butler with a branch pin to this branch (spress-build-sass):
`npm install --save --save-exact palantirnet/butler#spress-build-sass`
- Once completed, make a change to a .scss file. You should see command line output similar to: 
```
File /var/www/mitpress.local/styleguide/src/sass/_init.scss was changed, running tasks...
[14:35:35] Starting 'sass'...
Running Sass and PostCSS...
[14:35:35] Finished 'sass' after 352 ms
File /var/www/mitpress.local/styleguide/src/content/assets/css/styles.css was changed, updating spress...
[14:35:35] Starting 'spress-build'...
[14:35:37] Finished 'spress-build' after 1.89 s
```
- It might take a few seconds for the initial watch. I've found that subsequent changes to .scss files are updated much more quickly.