### PR TITLE
[SPRESS] Make sure SVGs can be included

### DIFF
--- a/STYLEGUIDE_TEMPLATE_SPRESS/config.yml
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/config.yml
@@ -3,6 +3,8 @@
 title: 'STYLEGUIDE TEMPLATE'
 url: ''
 
+text_extensions: [ 'htm', 'html', 'html.twig', 'twig.html', 'js', 'less', 'markdown', 'md', 'mkd', 'mkdn', 'coffee', 'css', 'erb', 'haml', 'handlebars', 'hb', 'ms', 'mustache', 'php', 'rb', 'sass', 'scss', 'slim', 'txt', 'xhtml', 'xml', 'svg' ]
+
 server_watch_ext: ['html', 'htm', 'xml', 'css', 'js', 'twig', 'md']
 
 collections:

--- a/STYLEGUIDE_TEMPLATE_SPRESS/config.yml
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/config.yml
@@ -3,7 +3,7 @@
 title: 'STYLEGUIDE TEMPLATE'
 url: ''
 
-text_extensions: [ 'htm', 'html', 'html.twig', 'twig.html', 'js', 'less', 'markdown', 'md', 'mkd', 'mkdn', 'coffee', 'css', 'erb', 'haml', 'handlebars', 'hb', 'ms', 'mustache', 'php', 'rb', 'sass', 'scss', 'slim', 'txt', 'xhtml', 'xml', 'svg' ]
+text_extensions: [ 'htm', 'html', 'html.twig', 'twig.html', 'js', 'less', 'markdown', 'md', 'mkd', 'mkdn', 'coffee', 'css', 'erb', 'haml', 'handlebars', 'hb', 'ms', 'mustache', 'php', 'rb', 'sass', 'scss', 'slim', 'txt', 'twig', 'xhtml', 'xml', 'svg' ]
 
 server_watch_ext: ['html', 'htm', 'xml', 'css', 'js', 'twig', 'md']
 


### PR DESCRIPTION
Issue: https://github.com/palantirnet/butler/issues/65

As outlined, if one tries to include an SVG in one's Twig file, nothing is printed. This pull request adds SVGs to the `text_extensions` variable to ensure they can be included.

To test:
The quickest, easiest way to test this is to update you config.yml file to reflect the changes as made by this PR. 

Alternatively, you can update you styleguide/package.json file and change (around line 15) the Butler dependency to point to the following hash: `207ef881d0aff81b6ce2935bbd3258055eb51e5b`. Then, you'll have to npm install again per the README's instructions for Butler

Either way, once you get the changes:
- Try to include an SVG for use in a Twig template. It should be printed.
- Update a Twig template. It should trigger a Spress rebuild.