### PR TITLE
Stop watching css, watch sass and run spress after sass is done

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -100,7 +100,7 @@ gulp.task('sculpin-prod', function () {
 
 // Spress Development
 gulp.task('spress-watch', function() {
-  var watcher = gulp.watch([defaults.spress_home + 'src/content/*', defaults.spress_home + 'src/**/*.html*', defaults.spress_home + 'src/content/assets/css/*'], ['spress-build']);
+  var watcher = gulp.watch([defaults.spress_home + 'src/content/*', defaults.spress_home + 'src/**/*.html*'], ['spress-build']);
   watcher.on('change', function(event) {
     console.log('File ' + event.path + ' was ' + event.type + ', updating spress...');
   });
@@ -117,12 +117,17 @@ gulp.task('spress-build', function () {
     .pipe(exec(defaults.spress_bin + ' site:build --source=' + defaults.spress_home));
 });
 
+gulp.task('spress-build-after-sass', ['sass'], function () {
+  return gulp.src(defaults.spress_home)
+    .pipe(exec(defaults.spress_bin + ' site:build --source=' + defaults.spress_home));
+});
+
 // Watch for Changes
 gulp.task('watch', function() {
   return gulp
   // Watch the scss folder for change
   // and run `compile-sass` task when something happens
-    .watch(defaults.scss, ['sass'])
+    .watch(defaults.scss, ['sass', 'spress-build-after-sass'])
     // When there is a change
     // log a message in the console
     .on('change', function (event) {


### PR DESCRIPTION
@labbydev this is a quick attempt to fix the was the issue I was mentioning. What I think the issue still is, is partly because Sass runs a lot slower than Spress, that the watcher for Spress was getting triggered as soon as Sass started updating css, but it would finish before sass finished, and then eventually the Spress watcher noticed the css was modified again once Sass was done and it would run again. It was taking about a minute before changes to css were appearing in the build. It looked like the sass task and spress-build task were chasing each other inefficiently. 

This change, which has Sass trigger the Spress-build only once it is done seems to fix it for me, and then all css changes show up when Spress is run the first time. 

My new task is a copy of spress-build, but with a dependency that Sass has run if it was triggered from the watch task. If we could trigger Sass-build from within the task that would be more dry, but I wasn't sure about the best Gulp way to do that. 