### PR TITLE
Spress deploy

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -141,7 +141,7 @@ gulp.task('spress-prod', function () {
 // Set a deploy task for spress
 gulp.task('spress-deploy', ['spress-prod'], function() {
   console.log('Beginning deploy to gh-pages for' + defaults.repo);
-  return gulp.src(defaults.spress_output)
+  return gulp.src(defaults.output_prod)
     .pipe(deploy(defaults.deploy))
     .on('end', function(){ console.log('Your styleguide has been deployed to' + defaults.repo); });
 });

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('spress-build-after-sass', ['sass'], function () {
 });
 
 //Build Spress Production Artifact
-gulp.task('spress-prod', function () {
+gulp.task('spress-prod', ['sass'],function () {
   console.log('Building production artifact...');
   console.log('WARNING: this will overwrite the existing build');
   return gulp.src(defaults.spress_home)
@@ -139,7 +139,7 @@ gulp.task('spress-prod', function () {
 });
 
 // Set a deploy task for spress
-gulp.task('spress-deploy', ['spress-prod'], function() {
+gulp.task('spress-deploy', ['sass', 'spress-prod'], function() {
   console.log('Beginning deploy to gh-pages for' + defaults.repo);
   return gulp.src(defaults.output_prod)
     .pipe(deploy(defaults.deploy))

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -98,6 +98,14 @@ gulp.task('sculpin-prod', function () {
     .on('end', function(){ console.log('Your production artifact has been built'); });
 });
 
+// Set a deploy task for sculpin
+gulp.task('sculpin-deploy', ['sculpin-prod'], function() {
+  console.log('Beginning deploy to gh-pages for' + defaults.repo);
+  return gulp.src(defaults.output_prod)
+    .pipe(deploy(defaults.deploy))
+    .on('end', function(){ console.log('Your styleguide has been deployed to' + defaults.repo); });
+});
+
 // Spress Development
 gulp.task('spress-watch', function() {
   var watcher = gulp.watch([defaults.spress_home + 'src/content/*', defaults.spress_home + 'src/**/*.html*'], ['spress-build']);
@@ -140,14 +148,6 @@ gulp.task('develop', defaults.develop_tasks);
 
 // Set a test task
 gulp.task('test', ['lint', 'audit']);
-
-// Set a deploy task
-gulp.task('deploy', ['sculpin-prod'], function() {
-  console.log('Beginning deploy to gh-pages for' + defaults.repo);
-  return gulp.src(defaults.output_prod)
-    .pipe(deploy(defaults.deploy))
-    .on('end', function(){ console.log('Your styleguide has been deployed to' + defaults.repo); });
-});
 
 
 //  Set default task

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -130,6 +130,22 @@ gulp.task('spress-build-after-sass', ['sass'], function () {
     .pipe(exec(defaults.spress_bin + ' site:build --source=' + defaults.spress_home));
 });
 
+//Build Spress Production Artifact
+gulp.task('spress-prod', function () {
+  console.log('Building production artifact...');
+  console.log('WARNING: this will overwrite the existing build');
+  return gulp.src(defaults.spress_home)
+    .pipe(exec(defaults.spress_bin + ' site:build --env=prod --source=' + defaults.spress_home));
+});
+
+// Set a deploy task for spress
+gulp.task('spress-deploy', ['spress-prod'], function() {
+  console.log('Beginning deploy to gh-pages for' + defaults.repo);
+  return gulp.src(defaults.spress_output)
+    .pipe(deploy(defaults.deploy))
+    .on('end', function(){ console.log('Your styleguide has been deployed to' + defaults.repo); });
+});
+
 // Watch for Changes
 gulp.task('watch', function() {
   return gulp

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A tool to automate front-end development tasks and streamline prototyping.
       "butler": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js",
       "develop": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js develop",
       "tests": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js test",
-      "deploy": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js deploy"
+      "deploy": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js sculpin-deploy"
     },
   ````
 1. Add the `node_modules` directory to your project's .gitignore
@@ -42,7 +42,7 @@ A tool to automate front-end development tasks and streamline prototyping.
   * `http://[project].local:8000` if you're running Butler on a Vagrant
   * [http://localhost:8000](http://localhost:8000) if you're developing locally
 
-## Add Butler to a project, with spress
+## Add Butler to a project, with Spress
 
 1. Log in to your vagrant environment and navigate to your project. You should always run `npm` commands from within your Vagrant:
 
@@ -75,14 +75,14 @@ npm install --save --save-exact palantirnet/butler#spress-task
   * Butler will ask you whether you're using Spress; say `y`
 1. Add Butler's scripts to your `package.json` file:
 
-  ```json
+  ````
     "scripts": {
       "butler": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js",
       "develop": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js develop",
       "tests": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js test",
-      "deploy": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js deploy"
+      "deploy": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js spress-deploy"
     },
-```
+`````
 1. Now make sure your Butler runs:
 
   ```
@@ -118,9 +118,9 @@ git commit -m "Initialize the styleguide."
 
   This is a task to deploy the static styleguide to GitHub pages.
 
-  Butler will build a Sculpin production artifact to `styleguide/output_prod` and deploy the production artifact to `gh-pages` branch of the repo defined in the `conf/butler.defaults.js`. Each commit for this process will default to the message: "Updated with Butler - [timestamp]".
+  Butler will build a Sculpin production artifact to and deploy the production artifact to `gh-pages` branch of the repo defined in the `conf/butler.defaults.js`. 
 
-  You may want to create a `sculpin_site_prod.yml` to define the site URL once deployed. You can find out more information about environment aware configuration for Sculpin [here](https://sculpin.io/documentation/configuration/).
+  You may want to create a `sculpin_site_prod.yml` or a `config_prod.yml` (for Spress) to define the site URL once deployed. You can find out more information about environment aware configuration for Sculpin [here](https://sculpin.io/documentation/configuration/) and the configuration for Spress [here](http://spress.yosymfony.com/docs/configuration/).
 
   *Note: When you are deploying, Butler will ask you for your GitHub credentials at least once, possibly multiple times. Enter your own GitHub credentials as prompted.*
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,17 @@ git commit -m "Initialize the styleguide."
 
   Butler will build a Sculpin production artifact to and deploy the production artifact to `gh-pages` branch of the repo defined in the `conf/butler.defaults.js`. 
 
-  You may want to create a `sculpin_site_prod.yml` or a `config_prod.yml` (for Spress) to define the site URL once deployed. You can find out more information about environment aware configuration for Sculpin [here](https://sculpin.io/documentation/configuration/) and the configuration for Spress [here](http://spress.yosymfony.com/docs/configuration/).
+  For Spress, you will need to create a a `config_prod.yml` to define the GitHub Pages site URL so that you can deploy to GitHub Pages. The `config_prod.yml` should go in the styleguide folder. Copy and paste this code into the `config_prod.yml` file:
+
+```
+# Site configuration
+
+url: 'https://palantirnet.github.io/[myproject]'
+``` 
+
+  For Sculpin, create a `sculpin_site_prod.yml`.
+
+  You can find out more information about environment aware configuration for Sculpin [here](https://sculpin.io/documentation/configuration/) and the configuration for Spress [here](http://spress.yosymfony.com/docs/configuration/).
 
   *Note: When you are deploying, Butler will ask you for your GitHub credentials at least once, possibly multiple times. Enter your own GitHub credentials as prompted.*
 

--- a/config/butler.defaults.js
+++ b/config/butler.defaults.js
@@ -19,6 +19,8 @@ defaults.output_dev = '../../styleguide/output_dev';
 defaults.html_files = ['../../styleguide/output_dev/*.html', '../../styleguide/output_dev/**/*.html'];
 // production files to be deployed
 defaults.output_prod = '../../styleguide/output_prod/**/*';
+// location of spress files
+defaults.spress_output = '../../styleguide/build/**/*';
 
 // location of sculpin.phar
 defaults.sculpin_run = '../../vendor/bin/sculpin';


### PR DESCRIPTION
Adds a deploy command for Spress

## Testing instructions
* add this branch (`spress-deploy`) as the butler version for a project
* update the `package.json scripts` based on the updated [README](https://github.com/palantirnet/butler/tree/spress-deploy#add-butler-to-a-project-with-spress)
* make sure your project has a `config_prod.yml` in the `styleguide` dir (this should include the gh-pages url)
* run `npm run deploy`
* Observe that the `build` directory has been updated
* Observe that the `build` directory has been deployed to `gh-pages` branch of the associated repository