### PR TITLE
Add sass to spress deploy

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -131,7 +131,7 @@ gulp.task('spress-build-after-sass', ['sass'], function () {
 });
 
 //Build Spress Production Artifact
-gulp.task('spress-prod', function () {
+gulp.task('spress-prod', ['sass'],function () {
   console.log('Building production artifact...');
   console.log('WARNING: this will overwrite the existing build');
   return gulp.src(defaults.spress_home)
@@ -139,7 +139,7 @@ gulp.task('spress-prod', function () {
 });
 
 // Set a deploy task for spress
-gulp.task('spress-deploy', ['spress-prod'], function() {
+gulp.task('spress-deploy', ['sass', 'spress-prod'], function() {
   console.log('Beginning deploy to gh-pages for' + defaults.repo);
   return gulp.src(defaults.output_prod)
     .pipe(deploy(defaults.deploy))


### PR DESCRIPTION
@labbydev this is a fix to the problem I was having in the spress deploy branch. It just makes sure sass is run as before building and deploying to gh-pages. 

To test delete all compiled css and delete your build before running 
`npm run deploy`
And make sure the pushed build on gh-pages includes css. 