### PR TITLE
add sass to run before spress-serve

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -106,7 +106,7 @@ gulp.task('spress-watch', function() {
   });
 });
 
-gulp.task('spress-serve', function () {
+gulp.task('spress-serve', ['sass'], function () {
   return gulp.src(defaults.spress_home)
     .pipe(exec('fuser 4000/tcp --kill || true'))
     .pipe(exec(defaults.spress_bin + ' site:build --server --source=' + defaults.spress_home));


### PR DESCRIPTION
This issue that I found easy to observe when running on my VM is that the latest css was not getting compiled when initially running Butler. I would sometimes either need to run butler twice or make some arbitrary sass change to trigger Butler to run.

To test:

Use this branch on a project by updating the packages.js to say `"butler": "github:palantirnet/butler#run-sass-initially"` on the butler dependancies line, and make sure you have deleted node_modules and the build directory as well as all compiled css in your project. 

Go to the styleguide folder in the VM and run npm install. 

Once that is done, test the two scenarios:

run `npm run butler' and make sure build is created with the current css.

stop butler and delete the build file, make a change to Sass, then run butler again and make sure the new css is compiled in the build. 


