### PR TITLE
Adds templates to collections in config.yml so that files in template…

### DIFF
--- a/STYLEGUIDE_TEMPLATE_SPRESS/config.yml
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/config.yml
@@ -25,3 +25,9 @@ collections:
     title: "High Fidelity Comps"
     sort_by: title
     sort_type: 'ascending'
+
+  templates:
+    output: true
+    title: "Templates"
+    sort_by: title
+    sort_type: 'ascending'


### PR DESCRIPTION
…s folder will automatically be linked on the homepage.

This pr ensures that all files in the templates folder are automatically linked on the styleguide index page.

To review, I recommend updating the config.yml file for a project that is using butler with spress. Then try adding a file to the templates folder. Check to see that it appears on the homepage.