### PR TITLE
Adds language attribute to default and template layouts.

### DIFF
--- a/STYLEGUIDE_TEMPLATE_SPRESS/src/layouts/default.html
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/src/layouts/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/STYLEGUIDE_TEMPLATE_SPRESS/src/layouts/template.html
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/src/layouts/template.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en-US">
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
This pr adds a language attribute to the `<html>` element in the default and template layouts. 

Specifying the language is good for accessibility and for search engines: https://www.w3schools.com/html/html_attributes.asp

To test, please review default.html and template.html to confirm that the language attribute has been added.