### PR TITLE
Adds correct description to components on index page.

### DIFF
--- a/STYLEGUIDE_TEMPLATE_SPRESS/src/content/index.html
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/src/content/index.html
@@ -27,7 +27,7 @@ title: Styleguide
     </div>
     <div class="styleguide-section">
       <h3 class="styleguide-title">Components</h3>
-      <p>Based on the needs of the content, Components are arranged into specific layouts to create Templates.</p>
+      <p>Components are grouped Elements that create a distinct section of an interface. They can be reordered and reused throughout the site.</p>
       <ul class="styleguide-list">
       {% for component in site.components %}
         <li><a href="{{ site.url }}{{ component.url }}">{{ component.title }}</a></li>


### PR DESCRIPTION
This pr corrects the component description on the index page. At some point, the template description was duplicated in this space.

To test, please:
1.) pull this branch.
2.) navigate to index.html
3.) confirm that the component description is no longer exactly the same as the template description.