### PR TITLE
Fixes typography errors

### DIFF
--- a/STYLEGUIDE_TEMPLATE_SPRESS/src/content/elements/element-typography.html
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/src/content/elements/element-typography.html
@@ -55,7 +55,7 @@ description: These are the baseline typographic styles for the website.
   <p><strong>Strong is used to indicate strong importance</strong></p>
   <p><em>This text has added emphasis</em></p>
   <p>The <b>b element</b> is stylistically different text from normal text, without any special importance</p>
-  <p>The <i>i element</i> is text that is set off from the normal text</p>
+  <p>The <em>em element</em> is text that is set off from the normal text</p>
   <p>The <u>u element</u> is text with an unarticulated, though explicitly rendered, non-textual annotation</p>
   <p><del>This text is deleted</del> and <ins>This text is inserted</ins></p>
   <p><s>This text has a strikethrough</s></p>

--- a/STYLEGUIDE_TEMPLATE_SPRESS/src/content/elements/element-typography.html
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/src/content/elements/element-typography.html
@@ -54,7 +54,7 @@ description: These are the baseline typographic styles for the website.
   <p><a href="#">This is a text link</a></p>
   <p><strong>Strong is used to indicate strong importance</strong></p>
   <p><em>This text has added emphasis</em></p>
-  <p>The <b>b element</b> is stylistically different text from normal text, without any special importance</p>
+  <p>The <strong>strong element</strong> is stylistically different text from normal text, without any special importance</p>
   <p>The <em>em element</em> is text that is set off from the normal text</p>
   <p>The <u>u element</u> is text with an unarticulated, though explicitly rendered, non-textual annotation</p>
   <p><del>This text is deleted</del> and <ins>This text is inserted</ins></p>


### PR DESCRIPTION
This pr fixes some errors I spotted on the typography element page. 

To test, please:
1.) pull this branch
2.) navigate to element-typography.html.
3.) on line 57, confirm that the `<b>` element has been replaced by the `<strong>` element.
4.) on line 58, confirm that the `<i>` element has been replaced by the `<strong>` element.