### PR TITLE
Add Vagrant environment specific config support

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -120,6 +120,12 @@ gulp.task('spress-serve', ['sass'], function () {
     .pipe(exec(defaults.spress_bin + ' site:build --server --source=' + defaults.spress_home));
 });
 
+gulp.task('spress-serve-vagrant', ['sass'], function () {
+    return gulp.src(defaults.spress_home)
+        .pipe(exec('fuser 4000/tcp --kill || true'))
+        .pipe(exec(defaults.spress_bin + ' site:build --server --env=vagrant --source=' + defaults.spress_home));
+});
+
 gulp.task('spress-build', function () {
   return gulp.src(defaults.spress_home)
     .pipe(exec(defaults.spress_bin + ' site:build --source=' + defaults.spress_home));
@@ -161,6 +167,9 @@ gulp.task('watch', function() {
 
 // Set Develop task
 gulp.task('develop', defaults.develop_tasks);
+
+// Set develop-vagrant task
+gulp.task('develop-vagrant', defaults.develop_tasks_vagrant);
 
 // Set a test task
 gulp.task('test', ['lint', 'audit']);

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm install --save --save-exact palantirnet/butler
   ````
     "scripts": {
       "butler": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js",
+      "butler-vagrant": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js develop-vagrant",
       "develop": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js develop",
       "tests": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js test",
       "deploy": "node_modules/butler/node_modules/.bin/gulp --gulpfile node_modules/butler/Gulpfile.js spress-deploy"

--- a/STYLEGUIDE_TEMPLATE_SPRESS/config_dev.yml
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/config_dev.yml
@@ -1,4 +1,0 @@
-# Site configuration
-
-url: ''
-debug: true

--- a/STYLEGUIDE_TEMPLATE_SPRESS/config_vagrant.yml
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/config_vagrant.yml
@@ -1,0 +1,3 @@
+# Site configuration for running Butler and Spress inside of vagrant
+url: ''
+debug: true


### PR DESCRIPTION
### Problem
Designers and developers often use Butler in different environments. Designers prefer to work locally for the increased speed, while developers work within Vagrant for Drupal support. Unfortunately, there is no easy way to differentiate this environment when running Butler. As a result, the URL in the `config.yml` file must be changed from something like `localhost:4000` to `project-name.local:4000` when the environment switches. This can be tedious to change and to avoid committing.

### Proposed Solution
This PR adds a special Gulp task named `butler-vagrant` for running Butler within Vagrant. It executes Spress with config for a new Vagrant environment located in the `config_vagrant.yml` file. 

It adds a task to Gulp named `spress-serve-vagrant` to serve content at the appropriate URL.

### Next steps

Spress is supposed to allow [per-environment configuration](http://spress.yosymfony.com/docs/configuration/). We previously had a `config_dev.yml` file. I couldn't get Spress to acknowledge the config in this file, but everything worked when I changed the environment from `dev` to `vagrant`. 

I currently have the `develop-vagrant` tasks defined in the `butler.defaults.js` file that is included in a project's overrides of the butler defaults. I don't believe this is the best place for it, but I wasn't sure where else to place it. Here is that code:
```
overrides.develop_tasks_vagrant = ['sass', 'spress-serve-vagrant', 'spress-watch', 'watch'];
```