### PR TITLE
Asks that cssnano ignore z-index

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -63,7 +63,7 @@ gulp.task('sass', function() {
   // runs autoprefixer and compresses CSS after compiling
   var processors = [
     autoprefixer(defaults.autoprefixer),
-    cssnano
+    cssnano({ zindex: false })
   ];
   // Run on all file defaults defined in var scsss
   return gulp.src(defaults.scss)


### PR DESCRIPTION
Cssnano will sometimes reset z-index values when sass is compiled. 

https://github.com/ben-eb/gulp-cssnano/issues/8
Update to cssnano? https://github.com/ben-eb/cssnano/issues/88

Current cssnano version is ^3.5.2