### PR TITLE
Update Butler's gulp-sass requirement to work with yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-gh-pages": "^0.5.4",
     "gulp-postcss": "^6.1.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.2.0",
+    "gulp-sass": "^3.0",
     "install": "^0.5.4",
     "npm": "^3.7.5",
     "postcss-reporter": "^1.3.3",


### PR DESCRIPTION
### Problem
While `yarn` may be run locally to compile styleguides, many of our deployment processes rely on building the styleguide prior to deployment. Therefore, when running `phing build` after upgrading a project to `yarn`, the styleguide is not built and the freshest CSS/JS is not deployed.

### Description
The current version of `gulp-sass` that we are using relies on a version of `node-sass` that has no compiled binaries for Linux. When running this from inside of Vagrant, errors are thrown as `yarn` attempts to build `node-sass` from source. It cannot build from source because `node-sass` 3.13.1 [only supports](https://github.com/sass/node-sass/releases/tag/v3.13.1) down to node 7. `yarn` requires node 9+. As a result, it is impossible to run `yarn` from within Vagrant.

### Solution
The solution is simple: change the dependency in Butler to use a newer version of `gulp-sass` (which therefore requires a newer version of `node-sass`). The latest versions support node 9 (and therefore `yarn`).

### To test
1. Delete your `node_modules/` folder
1. Run `yarn` from the `styleguide/` directory in a project
1. It should complete. Run `yarn run butler`. It should serve the styleguide.