### PR TITLE
Patch Singularity GS

### DIFF
--- a/config/butler.config.sh
+++ b/config/butler.config.sh
@@ -35,6 +35,11 @@ if [ ! -e ../../conf/butler.defaults.js ]; then
 
   echo "" >> ../../conf/butler.defaults.js
   echo "module.exports = overrides;" >> ../../conf/butler.defaults.js
+  
+  if [ ! -e ../../patches ]; then
+    mkdir ../../patches
+    cp -r patches/* ../../patches
+  fi;
 fi;
 
 echo ""

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8268,7 +8268,7 @@
         "asap": {
           "version": "2.0.4",
           "from": "asap@latest",
-          "resolved": "https://unpm.uberinternal.com/asap/-/asap-2.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.4.tgz"
         },
         "chownr": {
           "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "butler": "gulp develop",
     "linting": "gulp test",
     "deploy": "gulp deploy",
-    "postinstall": "./config/butler.config.sh"
+    "postinstall": "./config/butler.config.sh",
+    "prepare": "patch-package"
   },
   "repository": {
     "type": "git",
@@ -32,6 +33,7 @@
     "gulp-sass": "^3.0",
     "install": "^0.5.4",
     "npm": "^3.7.5",
+    "patch-package": "^5.1.1",
     "postcss-reporter": "^1.3.3",
     "postcss-scss": "^0.1.6",
     "singularitygs": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "singularitygs": "^1.7.0",
     "stylelint": "^4.4.0",
     "stylelint-selector-bem-pattern": "^0.2.1"
+  },
+  "devDependencies": {
+    "postinstall-prepare": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "gulp-sass": "^3.0",
     "install": "^0.5.4",
     "npm": "^3.7.5",
+    "patch-package": "^5.1.1",
     "postcss-reporter": "^1.3.3",
     "postcss-scss": "^0.1.6",
     "singularitygs": "^1.7.0",
@@ -39,7 +40,6 @@
     "stylelint-selector-bem-pattern": "^0.2.1"
   },
   "devDependencies": {
-    "patch-package": "^5.1.1",
     "postinstall-prepare": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "butler": "gulp develop",
     "linting": "gulp test",
     "deploy": "gulp deploy",
-    "postinstall": "./config/butler.config.sh",
-    "prepare": "patch-package"
+    "postinstall": "./config/butler.config.sh"
   },
   "repository": {
     "type": "git",
@@ -33,7 +32,6 @@
     "gulp-sass": "^3.0",
     "install": "^0.5.4",
     "npm": "^3.7.5",
-    "patch-package": "^5.1.1",
     "postcss-reporter": "^1.3.3",
     "postcss-scss": "^0.1.6",
     "singularitygs": "^1.7.0",
@@ -41,6 +39,7 @@
     "stylelint-selector-bem-pattern": "^0.2.1"
   },
   "devDependencies": {
+    "patch-package": "^5.1.1",
     "postinstall-prepare": "^1.0.1"
   }
 }

--- a/patches/singularitygs+1.8.0.patch
+++ b/patches/singularitygs+1.8.0.patch
@@ -1,0 +1,25 @@
+patch-package
+--- a/node_modules/singularitygs/stylesheets/singularitygs/_api.scss
++++ b/node_modules/singularitygs/stylesheets/singularitygs/_api.scss
+@@ -56,11 +56,19 @@
+     $Right: ();
+ 
+     @if $Direction == 'both' or $From == 'left' or ($Direction == 'rtl' and $From == 'opposite') {
+-      $Left: call('output-#{$output-style}', map-merge($Span-Map, ('direction': left)));
++      @if (function-exists('get-function')) {
++        $Left: call(get-function('output-#{$output-style}'), map-merge($Span-Map, ('direction': left)));
++      } @else {
++        $Left: call('output-#{$output-style}', map-merge($Span-Map, ('direction': left)));
++      }
+     }
+ 
+     @if $Direction == 'both' or $From == 'right' or ($Direction == 'ltr' and $From == 'opposite') {
+-      $Right: call('output-#{$output-style}', map-merge($Span-Map, ('direction': right)));
++      @if (function-exists('get-function')) {
++        $Right: call(get-function('output-#{$output-style}'), map-merge($Span-Map, ('direction': right)));
++      } @else {
++        $Right: call('output-#{$output-style}', map-merge($Span-Map, ('direction': right)));
++      }
+     }
+ 
+     $Left-Keys: map-keys($Left);


### PR DESCRIPTION
After updating gulp-sass on #100, several `DEPRECATED` warnings are issued when building the styleguide.  Singularity is EOL and no longer maintained, so it must be patched (see https://github.com/at-import/Singularity/releases/tag/v1.8.0).

This PR updates Butler using the method in https://github.com/at-import/Singularity/pull/245#issuecomment-398016368

After updating or creating the styleguide for a project, run:

-  `yarn patch-package`

This will apply the patch to your instance (it isn't automatically run when adding Butler).  The installation instructions in Butler's readme will need to be updated accordingly.  However, they are currently written for using `npm`.  The patch requires Yarn, because the path to Singularity doesn't include `node_modules/butler/node_modules`.

This PR also includes a limited update to `npm-shrinkwrap.json` that only changes the URL of the 'asap' package, removing the internal Uber path.  It replaces #90, since there were concerns there about regressions.