### PR TITLE
make sort-packages boolean in composer.json

### DIFF
--- a/STYLEGUIDE_TEMPLATE_SPRESS/composer.json
+++ b/STYLEGUIDE_TEMPLATE_SPRESS/composer.json
@@ -6,7 +6,7 @@
     "prefer-stable": true,
     "preferred-install": "dist",
     "config": {
-        "sort-packages": "true"
+        "sort-packages": true
     },
     "require": {
         "spress/spress": "^2.1"


### PR DESCRIPTION
Fixes error with newer versions of Composer that require `sort-packages` to be a boolean.
```
 [Composer\Json\JsonValidationException]                                  
  "./composer.json" does not match the expected JSON schema:               
   - config.sort-packages : String value found, but a boolean is required  
```